### PR TITLE
Add basic portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Portfolio Website
+
+This repository contains a simple portfolio website for a Full Stack Developer. The site includes four main pages:
+
+- `index.html` - Home page
+- `about.html` - About page
+- `projects.html` - Projects page
+- `contact-us.html` - Contact page
+
+## Usage
+
+Open any of the HTML files in your browser. If you want to serve the site locally, you can use a simple static server, for example with Python:
+
+```bash
+python3 -m http.server
+```
+
+Then visit `http://localhost:8000` in your browser.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Full Stack Developer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>About Me</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="projects.html">Projects</a>
+      <a href="contact-us.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Hi, I'm John Doe</h2>
+      <p>I am a passionate Full Stack Developer with experience building modern web applications using technologies like React, Node.js, and PostgreSQL. I enjoy crafting efficient backend services and polished front-end interfaces.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2023 John Doe</p>
+  </footer>
+</body>
+</html>

--- a/contact-us.html
+++ b/contact-us.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Contact - Full Stack Developer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Contact Me</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="projects.html">Projects</a>
+      <a href="contact-us.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Let's Connect</h2>
+      <form class="contact-form">
+        <label for="name">Name:</label>
+        <input type="text" id="name" name="name" required>
+
+        <label for="email">Email:</label>
+        <input type="email" id="email" name="email" required>
+
+        <label for="message">Message:</label>
+        <textarea id="message" name="message" required></textarea>
+
+        <button type="submit">Send</button>
+      </form>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2023 John Doe</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Full Stack Developer Portfolio</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>John Doe - Full Stack Developer</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="projects.html">Projects</a>
+      <a href="contact-us.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <section class="hero">
+      <h2>Welcome to my Portfolio</h2>
+      <p>I build scalable web applications and deliver delightful user experiences.</p>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2023 John Doe</p>
+  </footer>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Projects - Full Stack Developer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Projects</h1>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="about.html">About</a>
+      <a href="projects.html">Projects</a>
+      <a href="contact-us.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Selected Work</h2>
+      <article class="project">
+        <h3>Project One</h3>
+        <p>A web application built with React and Node.js that provides real-time data visualization.</p>
+      </article>
+      <article class="project">
+        <h3>Project Two</h3>
+        <p>An e-commerce platform with a custom API and secure user authentication.</p>
+      </article>
+    </section>
+  </main>
+  <footer>
+    <p>&copy; 2023 John Doe</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,84 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+  background-color: #f5f5f5;
+  color: #333;
+}
+
+header {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+
+nav {
+  margin-top: 0.5rem;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 1rem;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+main {
+  padding: 1rem;
+}
+
+.hero {
+  background-color: #eee;
+  padding: 2rem;
+  text-align: center;
+}
+
+.project {
+  background-color: #fff;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+}
+
+footer {
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  max-width: 400px;
+}
+
+.contact-form label {
+  margin-top: 0.5rem;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.5rem;
+  margin-top: 0.25rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.contact-form button {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  border: none;
+  background-color: #333;
+  color: #fff;
+  cursor: pointer;
+}
+
+.contact-form button:hover {
+  background-color: #555;
+}


### PR DESCRIPTION
## Summary
- add initial portfolio website with home, about, projects and contact pages
- include navigation, sample project descriptions and a contact form
- style pages with a simple CSS stylesheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e4f8447d88328ae77eb294fba384a